### PR TITLE
Fix for "fastify-plugin has no default export" Typescript error.

### DIFF
--- a/src/lib/content-parser.ts
+++ b/src/lib/content-parser.ts
@@ -1,5 +1,6 @@
 import { IncomingMessage } from 'http'
-import fp, { PluginOptions, nextCallback } from 'fastify-plugin'
+import * as fp from 'fastify-plugin'
+import { PluginOptions, nextCallback } from 'fastify-plugin'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 
 const kMultipart = Symbol('multipart')

--- a/src/lib/make-prehandler.ts
+++ b/src/lib/make-prehandler.ts
@@ -1,9 +1,9 @@
 import { ServerResponse } from 'http'
 import { FastifyReply, FastifyRequest } from 'fastify'
-import is from 'type-is'
-import Busboy from 'busboy'
-import extend from 'xtend'
-import onFinished from 'on-finished'
+import * as is from 'type-is'
+import * as Busboy from 'busboy'
+import * as extend from 'xtend'
+import * as onFinished from 'on-finished'
 import appendField from 'append-field'
 
 import Counter from './counter'

--- a/src/storage/disk.ts
+++ b/src/storage/disk.ts
@@ -1,10 +1,10 @@
 import { IncomingMessage } from 'http'
 import { FastifyRequest } from 'fastify'
 import { createWriteStream, unlink } from 'fs'
-import os from 'os'
+import * as os from 'os'
 import { join } from 'path'
-import crypto from 'crypto'
-import mkdirp from 'mkdirp'
+import * as crypto from 'crypto'
+import * as mkdirp from 'mkdirp'
 
 import { GetFileName, GetDestination, DiskStorageOptions, File, StorageEngine } from '../interfaces'
 

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage } from 'http'
 import { FastifyRequest } from 'fastify'
-import concat from 'concat-stream'
+import concat = require('concat-stream')
 
 import { StorageEngine, File } from '../interfaces'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "emitDecoratorMetadata": true,
     "strict": true,
     "noImplicitAny": false,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "removeComments": true,
     "noUnusedLocals": true,
     "lib": [

--- a/typings/append-field/index.d.ts
+++ b/typings/append-field/index.d.ts
@@ -1,4 +1,6 @@
-declare module 'append-field' {
-  function appendFile(store: any, key: string, value: string): void
-  export = appendFile
-}
+declare var appendField: {
+  appendFile(store: any, key: string, value: string): void;
+};
+
+
+export = appendField;


### PR DESCRIPTION
When using "fastify-multer" with TypeScript 3.4, I get an error saying: `"fastify-plugin" has no default export`. This PR fixes it.