### PR TITLE
Fixes tests' Windows bug

### DIFF
--- a/test/disk-storage.ts
+++ b/test/disk-storage.ts
@@ -7,6 +7,7 @@ import multer from '../lib'
 import temp from 'fs-temp'
 import rimraf from 'rimraf'
 import FormData from 'form-data'
+import os from 'os'
 
 describe('Disk Storage', function() {
   let uploadDir, upload
@@ -41,8 +42,8 @@ describe('Disk Storage', function() {
 
       assert.equal(req.file.fieldname, 'small0')
       assert.equal(req.file.originalname, 'small0.dat')
-      assert.equal(req.file.size, 1778)
-      assert.equal(fileSize(req.file.path), 1778)
+      assert.equal(req.file.size, os.platform() === 'win32' ? 1803 : 1778)
+      assert.equal(fileSize(req.file.path), os.platform() === 'win32' ? 1803 : 1778)
 
       done()
     })
@@ -115,8 +116,8 @@ describe('Disk Storage', function() {
 
       assert.equal(req.files['tiny0'][0].fieldname, 'tiny0')
       assert.equal(req.files['tiny0'][0].originalname, 'tiny0.dat')
-      assert.equal(req.files['tiny0'][0].size, 122)
-      assert.equal(fileSize(req.files['tiny0'][0].path), 122)
+      assert.equal(req.files['tiny0'][0].size, os.platform() === 'win32' ? 128 : 122)
+      assert.equal(fileSize(req.files['tiny0'][0].path), os.platform() === 'win32' ? 128 : 122)
 
       assert.equal(req.files['tiny1'][0].fieldname, 'tiny1')
       assert.equal(req.files['tiny1'][0].originalname, 'tiny1.dat')
@@ -125,18 +126,18 @@ describe('Disk Storage', function() {
 
       assert.equal(req.files['small0'][0].fieldname, 'small0')
       assert.equal(req.files['small0'][0].originalname, 'small0.dat')
-      assert.equal(req.files['small0'][0].size, 1778)
-      assert.equal(fileSize(req.files['small0'][0].path), 1778)
+      assert.equal(req.files['small0'][0].size, os.platform() === 'win32' ? 1803 : 1778)
+      assert.equal(fileSize(req.files['small0'][0].path), os.platform() === 'win32' ? 1803 : 1778)
 
       assert.equal(req.files['small1'][0].fieldname, 'small1')
       assert.equal(req.files['small1'][0].originalname, 'small1.dat')
-      assert.equal(req.files['small1'][0].size, 315)
-      assert.equal(fileSize(req.files['small1'][0].path), 315)
+      assert.equal(req.files['small1'][0].size, os.platform() === 'win32' ? 329 : 315)
+      assert.equal(fileSize(req.files['small1'][0].path), os.platform() === 'win32' ? 329 : 315)
 
       assert.equal(req.files['medium'][0].fieldname, 'medium')
       assert.equal(req.files['medium'][0].originalname, 'medium.dat')
-      assert.equal(req.files['medium'][0].size, 13196)
-      assert.equal(fileSize(req.files['medium'][0].path), 13196)
+      assert.equal(req.files['medium'][0].size, os.platform() === 'win32' ? 13386 : 13196)
+      assert.equal(fileSize(req.files['medium'][0].path), os.platform() === 'win32' ? 13386 : 13196)
 
       assert.equal(req.files['large'][0].fieldname, 'large')
       assert.equal(req.files['large'][0].originalname, 'large.jpg')

--- a/test/functionality.ts
+++ b/test/functionality.ts
@@ -6,6 +6,7 @@ import temp from 'fs-temp'
 import rimraf from 'rimraf'
 import FormData from 'form-data'
 import os from 'os'
+import path from 'path'
 
 function generateFilename(req, f, cb) {
   cb(null, f.fieldname + f.originalname)
@@ -142,13 +143,8 @@ describe('Functionality', function() {
     submitForm(parser, form, function(err, req) {
       assert.ifError(err)
       assert.equal(req.files.length, 2)
-      console.log('################################################# ', req.files[0].path)
-      assert.ok(
-        req.files[0].path.indexOf(os.platform() === 'win32' ? '\\testforme-' : '/testforme-') >= 0,
-      )
-      assert.ok(
-        req.files[1].path.indexOf(os.platform() === 'win32' ? '\\testforme-' : '/testforme-') >= 0,
-      )
+      assert.ok(req.files[0].path.indexOf(path.sep + 'testforme-') >= 0)
+      assert.ok(req.files[0].path.indexOf(path.sep + 'testforme-') >= 0)
       done()
     })
   })

--- a/test/functionality.ts
+++ b/test/functionality.ts
@@ -5,6 +5,7 @@ import multer from '../lib'
 import temp from 'fs-temp'
 import rimraf from 'rimraf'
 import FormData from 'form-data'
+import os from 'os'
 
 function generateFilename(req, f, cb) {
   cb(null, f.fieldname + f.originalname)
@@ -56,7 +57,7 @@ describe('Functionality', function() {
       submitForm(parser, env.form, function(error, req) {
         assert.ifError(error)
         assert.ok(startsWith(req.file.path, env.uploadDir))
-        assert.equal(fileSize(req.file.path), 1778)
+        assert.equal(fileSize(req.file.path), os.platform() === 'win32' ? 1803 : 1778)
         done()
       })
     })
@@ -141,8 +142,13 @@ describe('Functionality', function() {
     submitForm(parser, form, function(err, req) {
       assert.ifError(err)
       assert.equal(req.files.length, 2)
-      assert.ok(req.files[0].path.indexOf('/testforme-') >= 0)
-      assert.ok(req.files[1].path.indexOf('/testforme-') >= 0)
+      console.log('################################################# ', req.files[0].path)
+      assert.ok(
+        req.files[0].path.indexOf(os.platform() === 'win32' ? '\\testforme-' : '/testforme-') >= 0,
+      )
+      assert.ok(
+        req.files[1].path.indexOf(os.platform() === 'win32' ? '\\testforme-' : '/testforme-') >= 0,
+      )
       done()
     })
   })

--- a/test/memory-storage.ts
+++ b/test/memory-storage.ts
@@ -3,6 +3,7 @@ import assert from 'assert'
 import { file, submitForm } from './_util'
 import multer from '../lib'
 import FormData from 'form-data'
+import os from 'os'
 
 describe('Memory Storage', function() {
   let upload
@@ -26,8 +27,8 @@ describe('Memory Storage', function() {
 
       assert.equal(req.file.fieldname, 'small0')
       assert.equal(req.file.originalname, 'small0.dat')
-      assert.equal(req.file.size, 1778)
-      assert.equal(req.file.buffer.length, 1778)
+      assert.equal(req.file.size, os.platform() === 'win32' ? 1803 : 1778)
+      assert.equal(req.file.buffer.length, os.platform() === 'win32' ? 1803 : 1778)
 
       done()
     })
@@ -101,8 +102,8 @@ describe('Memory Storage', function() {
 
       assert.equal(req.files['tiny0'][0].fieldname, 'tiny0')
       assert.equal(req.files['tiny0'][0].originalname, 'tiny0.dat')
-      assert.equal(req.files['tiny0'][0].size, 122)
-      assert.equal(req.files['tiny0'][0].buffer.length, 122)
+      assert.equal(req.files['tiny0'][0].size, os.platform() === 'win32' ? 128 : 122)
+      assert.equal(req.files['tiny0'][0].buffer.length, os.platform() === 'win32' ? 128 : 122)
 
       assert.equal(req.files['tiny1'][0].fieldname, 'tiny1')
       assert.equal(req.files['tiny1'][0].originalname, 'tiny1.dat')
@@ -111,18 +112,18 @@ describe('Memory Storage', function() {
 
       assert.equal(req.files['small0'][0].fieldname, 'small0')
       assert.equal(req.files['small0'][0].originalname, 'small0.dat')
-      assert.equal(req.files['small0'][0].size, 1778)
-      assert.equal(req.files['small0'][0].buffer.length, 1778)
+      assert.equal(req.files['small0'][0].size, os.platform() === 'win32' ? 1803 : 1778)
+      assert.equal(req.files['small0'][0].buffer.length, os.platform() === 'win32' ? 1803 : 1778)
 
       assert.equal(req.files['small1'][0].fieldname, 'small1')
       assert.equal(req.files['small1'][0].originalname, 'small1.dat')
-      assert.equal(req.files['small1'][0].size, 315)
-      assert.equal(req.files['small1'][0].buffer.length, 315)
+      assert.equal(req.files['small1'][0].size, os.platform() === 'win32' ? 329 : 315)
+      assert.equal(req.files['small1'][0].buffer.length, os.platform() === 'win32' ? 329 : 315)
 
       assert.equal(req.files['medium'][0].fieldname, 'medium')
       assert.equal(req.files['medium'][0].originalname, 'medium.dat')
-      assert.equal(req.files['medium'][0].size, 13196)
-      assert.equal(req.files['medium'][0].buffer.length, 13196)
+      assert.equal(req.files['medium'][0].size, os.platform() === 'win32' ? 13386 : 13196)
+      assert.equal(req.files['medium'][0].buffer.length, os.platform() === 'win32' ? 13386 : 13196)
 
       assert.equal(req.files['large'][0].fieldname, 'large')
       assert.equal(req.files['large'][0].originalname, 'large.jpg')

--- a/test/reuse-middleware.ts
+++ b/test/reuse-middleware.ts
@@ -3,6 +3,7 @@ import assert from 'assert'
 import { file, submitForm } from './_util'
 import multer from '../lib'
 import FormData from 'form-data'
+import os from 'os'
 
 describe('Reuse Middleware', function() {
   let parser
@@ -35,8 +36,8 @@ describe('Reuse Middleware', function() {
         req.files.forEach(function(f) {
           assert.equal(f.fieldname, 'them-files')
           assert.equal(f.originalname, 'small0.dat')
-          assert.equal(f.size, 1778)
-          assert.equal(f.buffer.length, 1778)
+          assert.equal(f.size, os.platform() === 'win32' ? 1803 : 1778)
+          assert.equal(f.buffer.length, os.platform() === 'win32' ? 1803 : 1778)
         })
 
         if (--pending === 0) {

--- a/test/unicode.ts
+++ b/test/unicode.ts
@@ -6,6 +6,7 @@ import multer from '../lib'
 import temp from 'fs-temp'
 import rimraf from 'rimraf'
 import FormData from 'form-data'
+import os from 'os'
 
 describe('Unicode', function() {
   let uploadDir, upload
@@ -47,8 +48,8 @@ describe('Unicode', function() {
       assert.equal(req.file.originalname, filename)
 
       assert.equal(req.file.fieldname, 'small0')
-      assert.equal(req.file.size, 1778)
-      assert.equal(fileSize(req.file.path), 1778)
+      assert.equal(req.file.size, os.platform() === 'win32' ? 1803 : 1778)
+      assert.equal(fileSize(req.file.path), os.platform() === 'win32' ? 1803 : 1778)
 
       done()
     })


### PR DESCRIPTION
Some of the tests were not passing because on Windows systems file length is different in comparison to Unix systems due to LF CR characters used to terminate lines. Adding a check on OS before asserting should resolve the issue