### PR TITLE
Fix for "cannot find module" error on AWS Lambda function

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fastify-multer",
   "description": "Fastify plugin for handling `multipart/form-data`.",
   "version": "1.4.7",
-  "main": "lib/",
+  "main": "lib/index.js",
   "types": "lib/",
   "contributors": [
     "Maksim Sinik <maksim@sinik.it>",


### PR DESCRIPTION
"main" package.json config has to include full path to "index.js" file. Otherwise AWS Lambda function throws an error saying "cannot find module 'fastify-multer'".

More info:
https://forums.aws.amazon.com/thread.jspa?threadID=181471